### PR TITLE
Change the unique identifier of contacts from _ID to LOOKUP_KEY on Android

### DIFF
--- a/android/src/main/java/ch/byrds/capacitorcontacts/CapContacts.java
+++ b/android/src/main/java/ch/byrds/capacitorcontacts/CapContacts.java
@@ -69,7 +69,7 @@ public class CapContacts extends Plugin {
                 null);
         while (dataCursor.moveToNext()) {
             JSObject jsContact = new JSObject();
-            String contactId = dataCursor.getString(dataCursor.getColumnIndex(ContactsContract.Contacts._ID));
+            String contactId = dataCursor.getString(dataCursor.getColumnIndex(ContactsContract.Contacts.LOOKUP_KEY));
             jsContact.put(CONTACT_ID, contactId);
             jsContact.put(DISPLAY_NAME, dataCursor.getString(dataCursor.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME_PRIMARY)));
 


### PR DESCRIPTION
A sync or aggregation operation can change the _ID of contacts while the LOOKUP_KEY remains intact.
@see: https://developer.android.com/reference/android/provider/ContactsContract.Contacts